### PR TITLE
Drivers/DwUsb: set usb string descriptor

### DIFF
--- a/Drivers/Usb/DwUsbDxe/DwUsbDxe.c
+++ b/Drivers/Usb/DwUsbDxe/DwUsbDxe.c
@@ -714,6 +714,9 @@ DwUsbStart (
 
   // Right now we just support one configuration
   ASSERT (mDeviceDescriptor->NumConfigurations == 1);
+  mDeviceDescriptor->StrManufacturer = 1;
+  mDeviceDescriptor->StrProduct = 2;
+  mDeviceDescriptor->StrSerialNumber = 3;
   // ... and one interface
   mConfigDescriptor = (USB_CONFIG_DESCRIPTOR *)mDescriptors;
   ASSERT (mConfigDescriptor->NumInterfaces == 1);


### PR DESCRIPTION
Avoid to change the usb string descriptor in common driver. Set it in
DwUsb driver instead.

In the future, it should be moved into platform usb driver. Since DwUsb
driver should be common to different vendor's board too.

Contributed-under: TianoCore Contribution Agreement 1.0
Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
