### PR TITLE
HiKey: make linux sd boot entry look for BOOTAA64.EFI

### DIFF
--- a/Platforms/Hisilicon/HiKey/HiKeyDxe/InstallBootMenu.c
+++ b/Platforms/Hisilicon/HiKey/HiKeyDxe/InstallBootMenu.c
@@ -87,8 +87,8 @@ STATIC struct HiKeyBootEntry LinuxEntries[] = {
     LOAD_OPTION_CATEGORY_APP
   },
   [HIKEY_BOOT_ENTRY_BOOT_SD] = {
-    L"VenHw(594BFE73-5E18-4F12-8119-19DB8C5FC849)/HD(1,MBR,0x00000000,0x3F,0x21FC0)/Image",
-    L"dtb=hi6220-hikey.dtb console=ttyAMA3,115200 earlycon=pl011,0xf7113000 root=/dev/mmcblk1p2 rw rootwait initrd=initrd.img efi=noruntime",
+    L"VenHw(594BFE73-5E18-4F12-8119-19DB8C5FC849)/HD(1,MBR,0x00000000,0x3F,0x21FC0)/\\EFI\\BOOT\\BOOTAA64.EFI",
+    NULL,
     L"boot from SD card",
     LOAD_OPTION_CATEGORY_BOOT
   }


### PR DESCRIPTION
Better to use the generic EFI firmware name when producing images that can be loaded via external devices, such as sdcard and usb. With this change, any distro can be easily supported as long they provide a MBR SD card setup with 2 partitions, and the first (fat) providing one compatible EFI bootloader as BOOTAA64.EFI.

Tested with https://builds.96boards.org/snapshots/reference-platform/debian/latest/hikey/hikey-debian-jessie-alip-20160503-84.img.gz flashed in a sdcard.

Since LeMaker is not yet using this firmware for factory, we can work with them to convert their image to be compatible with this new path/scheme.
