### PR TITLE
OpenPlatformPkg: HiKeyMem: Initialize the base system memory HOB befo…

### DIFF
--- a/Platforms/Hisilicon/HiKey/Library/HiKeyLib/HiKeyMem.c
+++ b/Platforms/Hisilicon/HiKey/Library/HiKeyLib/HiKeyMem.c
@@ -89,6 +89,24 @@ ArmPlatformGetVirtualMemoryMap (
 
   MemorySize = HiKeyInitMemorySize ();
 
+  ResourceAttributes = (
+      EFI_RESOURCE_ATTRIBUTE_PRESENT |
+      EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
+      EFI_RESOURCE_ATTRIBUTE_UNCACHEABLE |
+      EFI_RESOURCE_ATTRIBUTE_WRITE_COMBINEABLE |
+      EFI_RESOURCE_ATTRIBUTE_WRITE_THROUGH_CACHEABLE |
+      EFI_RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE |
+      EFI_RESOURCE_ATTRIBUTE_TESTED
+  );
+
+  // Create initial Base Hob for system memory.
+  BuildResourceDescriptorHob (
+      EFI_RESOURCE_SYSTEM_MEMORY,
+      ResourceAttributes,
+      PcdGet64 (PcdSystemMemoryBase),
+      PcdGet64 (PcdSystemMemorySize)
+  );
+
   NextHob.Raw = GetHobList ();
   Count = sizeof (HiKeyReservedMemoryBuffer) / sizeof (struct HiKeyReservedMemory);
   while ((NextHob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, NextHob.Raw)) != NULL)


### PR DESCRIPTION
…re trying to create reservations

In the current edk2 code, as of 40a3f38f67cee
("ArmPlatformPkg/MemoryInitPei: Check if the main System
Memory resource has been declared"), ArmPlatformGetVirtualMemoryMap()
is now called before the base system memory HOB is created in
MemoryPeim().

This causes the logic in HiKey's ArmPlatformGetVirtualMemoryMap()
which tries to chop up that base HOB to fail, as there's nothing
to chop up at that time.

The calling code is smart enough to check if a base system memory
HOB is already present before creating one, so we can just set it
up ourselves here before we try to make our reservations.

This avoids problems seen in the kernel with the current logic,
where none of the reservations were actually being made.

Note: I'm a total newbie with this codebase (I just recently
figured out what HOB stood for). So feedback would be greatly
appreciated!

CC: Olivier Martin Olivier.Martin@arm.com
Cc: Haojian Zhuang haojian.zhuang@linaro.org
Cc: Vishal Bhoj vishal.bhoj@linaro.org
Signed-off-by: John Stultz john.stultz@linaro.org
