### PR TITLE
hikey: enable GPU mtcmos

### DIFF
--- a/Chips/Hisilicon/Hi6220/Include/Hi6220.h
+++ b/Chips/Hisilicon/Hi6220/Include/Hi6220.h
@@ -63,6 +63,13 @@
 #define MDDRC_AXI_BASE                          0xF7120000
 #define AXI_REGION_MAP_OFFSET(x)                ( 0x100 + ( x ) * 0x10 )
 
+#define AO_CTRL_BASE				0xF7800000
+#define SC_PW_MTCMOS_EN0			0x830
+#define SC_PW_MTCMOS_DIS0			0x834
+#define SC_PW_MTCMOS_STAT0			0x838
+#define SC_PW_MTCMOS_ACK_STAT0			0x83c
+#define PW_EN0_G3D				(1 << 1)
+
 #define PMUSSI_BASE                             0xF8000000
 
 #endif	/* __HI6220_H__ */

--- a/Platforms/Hisilicon/HiKey/HiKeyDxe/InitPeripherals.c
+++ b/Platforms/Hisilicon/HiKey/HiKeyDxe/InitPeripherals.c
@@ -178,6 +178,21 @@ UartInit (
   MmioWrite32 (PMUSSI_REG(0x1c), Val);
 }
 
+STATIC
+VOID
+MtcmosInit (
+  IN VOID
+  )
+{
+  UINT32     Data;
+
+  /* enable MTCMOS for GPU */
+  MmioWrite32 (AO_CTRL_BASE + SC_PW_MTCMOS_EN0, PW_EN0_G3D);
+  do {
+    Data = MmioRead32 (AO_CTRL_BASE + SC_PW_MTCMOS_ACK_STAT0);
+  } while ((Data & PW_EN0_G3D) == 0);
+}
+
 EFI_STATUS
 HiKeyInitPeripherals (
   IN VOID
@@ -195,6 +210,7 @@ HiKeyInitPeripherals (
   } while (Data & Bits);
 
   UartInit ();
+  MtcmosInit ();
 
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
Make GPU MTCMOS always enabled.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
