### PR TITLE
Platforms/HiKey: make DW_MMC2 out of reset

### DIFF
--- a/Platforms/Hisilicon/HiKey/HiKeyDxe/Hi6220RegsPeri.h
+++ b/Platforms/Hisilicon/HiKey/HiKeyDxe/Hi6220RegsPeri.h
@@ -18,8 +18,12 @@
 
 #define SC_PERIPH_CLKEN3                0x230
 #define SC_PERIPH_RSTEN3                0x330
+#define SC_PERIPH_RSTDIS0               0x304
 #define SC_PERIPH_RSTDIS3               0x334
 #define SC_PERIPH_RSTSTAT3              0x338
+
+/* SC_PERIPH_RSTEN0/RSTDIS0/RSTSTAT0 */
+#define PERIPH_RST0_MMC2                (1 << 2)
 
 /* SC_PERIPH_RSTEN3/RSTDIS3/RSTSTAT3 */
 #define PERIPH_RST3_CSSYS               (1 << 0)

--- a/Platforms/Hisilicon/HiKey/HiKeyDxe/InitPeripherals.c
+++ b/Platforms/Hisilicon/HiKey/HiKeyDxe/InitPeripherals.c
@@ -173,6 +173,9 @@ UartInit (
   MmioWrite32 (PERI_CTRL_BASE + SC_PERIPH_RSTDIS3, PERIPH_RST3_UART4);
   MmioWrite32 (PERI_CTRL_BASE + SC_PERIPH_CLKEN3, PERIPH_RST3_UART4);
 
+  /* make DW_MMC2 out of reset */
+  MmioWrite32 (PERI_CTRL_BASE + SC_PERIPH_RSTDIS0, PERIPH_RST0_MMC2);
+
   /* enable clock for BT/WIFI */
   Val = MmioRead32 (PMUSSI_REG(0x1c)) | 0x40;
   MmioWrite32 (PMUSSI_REG(0x1c), Val);


### PR DESCRIPTION
Unreset DW_MMC2.

By doing this, in kernel dw_mmc driver, we don't need to reset dw_mmc2
host controller again.

Signed-off-by: Guodong Xu guodong.xu@linaro.org
