### PR TITLE
HiKey: fix the truncated serial number string

### DIFF
--- a/Platforms/Hisilicon/HiKey/HiKeyDxe/HiKeyDxe.c
+++ b/Platforms/Hisilicon/HiKey/HiKeyDxe/HiKeyDxe.c
@@ -29,7 +29,7 @@
 
 #include "HiKeyDxeInternal.h"
 
-#define SERIAL_NUMBER_LENGTH        16
+#define SERIAL_NUMBER_LENGTH        17
 #define SERIAL_NUMBER_LBA           1024
 #define SERIAL_NUMBER_BLOCK_SIZE    512
 #define RANDOM_MAGIC                0x9a4dbeaf
@@ -162,6 +162,7 @@ GetSerialNo (
     return Status;
   }
   CopyMem (SerialNo, DataUnicode, VariableSize);
+  *Length = VariableSize;
   return EFI_SUCCESS;
 }
 


### PR DESCRIPTION
Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
