### PR TITLE
DwSdDxe: avoid sd hang

### DIFF
--- a/Drivers/Mmc/DwSdDxe/DwSdDxe.c
+++ b/Drivers/Mmc/DwSdDxe/DwSdDxe.c
@@ -287,10 +287,6 @@ SendCommand (
   MmioWrite32 (DWSD_RINTSTS, ~0);
   MmioWrite32 (DWSD_CMDARG, Argument);
   MicroSecondDelay(500);
-  // Wait until MMC is idle
-  do {
-    Data = MmioRead32 (DWSD_STATUS);
-  } while (Data & DWSD_STS_DATA_BUSY);
 
   MmioWrite32 (DWSD_CMD, MmcCmd);
 


### PR DESCRIPTION
If keep polling SD_STATUS register, it's pending on DATA_BUSY signal.
This behavior makes SD card hang. After removing this polling, this
issue could be fixed.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
