### PR TITLE
Fix abootimg support broken by ("fix the truncated serial number stri…

### DIFF
--- a/Platforms/Hisilicon/HiKey/HiKeyDxe/HiKeyDxe.c
+++ b/Platforms/Hisilicon/HiKey/HiKeyDxe/HiKeyDxe.c
@@ -29,7 +29,7 @@
 
 #include "HiKeyDxeInternal.h"
 
-#define SERIAL_NUMBER_LENGTH        17
+#define SERIAL_NUMBER_LENGTH        16
 #define SERIAL_NUMBER_LBA           1024
 #define SERIAL_NUMBER_BLOCK_SIZE    512
 #define RANDOM_MAGIC                0x9a4dbeaf


### PR DESCRIPTION
…ng")

The commit 3aa3378206e ("HiKey: fix the truncated serial number string")
broke abootimg support, rendering systems flashed with flashall.sh to
stop booting.

This change seems to make it work again.

Change-Id: I43495bc178175c0f4814b58a1c925f0fbf6c1b98
Signed-off-by: John Stultz john.stultz@linaro.org
