### PR TITLE
HiKeyFastboot.c: add support for sparse image with CHUNK_TYPE_FILL

### DIFF
--- a/Platforms/Hisilicon/HiKey/HiKeyFastbootDxe/HiKeyFastboot.c
+++ b/Platforms/Hisilicon/HiKey/HiKeyFastbootDxe/HiKeyFastboot.c
@@ -363,6 +363,7 @@ HiKeyFastbootPlatformFlashPartition (
   CHUNK_HEADER            *ChunkHeader;
   UINTN                    Offset = 0;
   UINT32                   Chunk, EntrySize, EntryOffset;
+  UINT32                  *FillVal, TmpCount, FillBuf[1024];
   VOID                    *Buffer;
 
 
@@ -468,6 +469,27 @@ HiKeyFastbootPlatformFlashPartition (
             return Status;
           }
           Image+=WriteSize;
+          break;
+        case CHUNK_TYPE_FILL:
+          //Assume fillVal is 0, and we can skip here
+          FillVal = (UINT32 *)Image;
+          Image += sizeof(UINT32);
+          if (*FillVal != 0){
+            mTextOut->OutputString(mTextOut, OutputString);
+            for(TmpCount = 0; TmpCount < 1024; TmpCount++){
+                FillBuf[TmpCount] = *FillVal;
+            }
+            for (TmpCount= 0; TmpCount < WriteSize; TmpCount += sizeof(FillBuf)) {
+                if ((WriteSize - TmpCount) < sizeof(FillBuf)) {
+                  Status = DiskIo->WriteDisk (DiskIo, MediaId, Offset + TmpCount, WriteSize - TmpCount, FillBuf);
+                } else {
+                  Status = DiskIo->WriteDisk (DiskIo, MediaId, Offset + TmpCount, sizeof(FillBuf), FillBuf);
+                }
+                if (EFI_ERROR (Status)) {
+                    return Status;
+                }
+            }
+          }
           break;
         case CHUNK_TYPE_DONT_CARE:
           break;


### PR DESCRIPTION
since the sparse image generated with img2simg command will have
CHUNK_TYPE_FILL type trunk, and it's better to have support for that,
so that we can try other file system type with img2simg command.

And we will ignore the FILL type chunk if it is filled with 0.

If the it's not filled with 0, it will need more time to finish the flash

Change-Id: I33ec90dbb0255b59cf5afcad67061fa7a89be106
Signed-off-by: Yongqin Liu yongqin.liu@linaro.org
