### PR TITLE
hikey: Change PcdFirmwareVendor to "hikey"

### DIFF
--- a/Platforms/Hisilicon/HiKey/HiKey.dsc
+++ b/Platforms/Hisilicon/HiKey/HiKey.dsc
@@ -257,7 +257,7 @@
   gEmbeddedTokenSpaceGuid.PcdEmbeddedDefaultTextColor|0x07
   gEmbeddedTokenSpaceGuid.PcdEmbeddedMemVariableStoreSize|0x10000
 
-  gArmPlatformTokenSpaceGuid.PcdFirmwareVendor|"Hisilicon HiKey"
+  gArmPlatformTokenSpaceGuid.PcdFirmwareVendor|"hikey"
   gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString|L"Alpha"
   gEmbeddedTokenSpaceGuid.PcdEmbeddedPrompt|"HiKey"
 


### PR DESCRIPTION
$ fastboot getvar product - should be consistent with
ro.product.device value that is set from the build.

Change-Id: Ia4add81903b700d8b22d297b05d76b801c6ea0df
Signed-off-by: Dmitry Shmidt dimitrysh@google.com
