### PR TITLE
HiKeyFastboot: Add short delay after flush to avoid reboot hang

### DIFF
--- a/Platforms/Hisilicon/HiKey/HiKeyFastbootDxe/HiKeyFastboot.c
+++ b/Platforms/Hisilicon/HiKey/HiKeyFastbootDxe/HiKeyFastboot.c
@@ -33,6 +33,7 @@
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
 #include <Library/PrintLib.h>
+#include <Library/TimerLib.h>
 
 #include <Guid/HiKeyVariable.h>
 
@@ -557,6 +558,7 @@ HiKeyFastbootPlatformFlashPartition (
   }
 
   BlockIo->FlushBlocks(BlockIo);
+  MicroSecondDelay (50000);
 
   return Status;
 }

--- a/Platforms/Hisilicon/HiKey/HiKeyFastbootDxe/HiKeyFastbootDxe.inf
+++ b/Platforms/Hisilicon/HiKey/HiKeyFastbootDxe/HiKeyFastbootDxe.inf
@@ -35,6 +35,7 @@
   UefiBootServicesTableLib
   UefiRuntimeServicesTableLib
   UefiDriverEntryPoint
+  TimerLib
 
 [Protocols]
   gAndroidFastbootPlatformProtocolGuid


### PR DESCRIPTION
We've frequently seen hangs after flashing partitions on HiKey.
It tends to happen when the flash and reboot commands happen very close
together:
 $ fastboot flash <partition> <image>; fastboot reboot;

Tracing through this, the Flush completes, and then we process
the fastboot reboot command, which issues the PSCI_RESET command
and we seem to hang in PSCI_RESET.

This seems to point to some sort of a hardware issue where the
RESET command may not actually trigger the hardware to reset if
there's some sort of IO still in flight. The flush command
shouldn't return early, but something is not quite right here.

In order to avoid the issue, this patch adds a short delay
after the flush command. With this delay, I can no longer
trigger the reset hang.

Change-Id: I9ccbcdcc597c4546808777c06ecd3f252df15008
Signed-off-by: John Stultz john.stultz@linaro.org
