### PR TITLE
Platforms/HiKey: fix to clear reboot reason

### DIFF
--- a/Platforms/Hisilicon/HiKey/HiKeyDxe/HiKeyDxe.c
+++ b/Platforms/Hisilicon/HiKey/HiKeyDxe/HiKeyDxe.c
@@ -323,6 +323,7 @@ VirtualKeyboardClear (
   }
   if (MmioRead32 (ADB_REBOOT_ADDRESS) == ADB_REBOOT_BOOTLOADER) {
     MmioWrite32 (ADB_REBOOT_ADDRESS, ADB_REBOOT_NONE);
+    WriteBackInvalidateDataCacheRange ((VOID *)ADB_REBOOT_ADDRESS, 4);
   }
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
Flush caches after reboot reason is cleared. Otherwise, the clearing
feature doesn't work in release mode.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>