### PR TITLE
Platforms/Hisilicon: add fasboot parameters

### DIFF
--- a/Platforms/Hisilicon/HiKey/HiKeyFastbootDxe/HiKeyFastbootDxe.c
+++ b/Platforms/Hisilicon/HiKey/HiKeyFastbootDxe/HiKeyFastbootDxe.c
@@ -46,6 +46,8 @@
 #define ADB_REBOOT_ADDRESS               0x05F01000
 #define ADB_REBOOT_BOOTLOADER            0x77665500
 
+#define MMC_BLOCK_SIZE                   512
+
 typedef struct _FASTBOOT_PARTITION_LIST {
   LIST_ENTRY  Link;
   CHAR16      PartitionName[PARTITION_NAME_MAX_LENGTH];
@@ -514,6 +516,10 @@ HiKeyFastbootPlatformGetVar (
     } else {
       AsciiStrCpy (Value, "raw");
     }
+  } else if ( !AsciiStrCmp (Name, "erase-block-size")) {
+    AsciiSPrint (Value, 12, "0x%llx", MMC_BLOCK_SIZE);
+  } else if ( !AsciiStrCmp (Name, "logical-block-size")) {
+    AsciiSPrint (Value, 12, "0x%llx", MMC_BLOCK_SIZE);
   } else {
     *Value = '\0';
   }

--- a/Platforms/Hisilicon/HiKey960/HiKey960FastbootDxe/HiKey960FastbootDxe.c
+++ b/Platforms/Hisilicon/HiKey960/HiKey960FastbootDxe/HiKey960FastbootDxe.c
@@ -48,6 +48,8 @@
 #define ADB_REBOOT_ADDRESS               0x32100000
 #define ADB_REBOOT_BOOTLOADER            0x77665500
 
+#define UFS_BLOCK_SIZE                   4096
+
 typedef struct _FASTBOOT_PARTITION_LIST {
   LIST_ENTRY  Link;
   CHAR16      PartitionName[PARTITION_NAME_MAX_LENGTH];
@@ -593,6 +595,10 @@ HiKey960FastbootPlatformGetVar (
     } else {
       AsciiStrCpy (Value, "raw");
     }
+  } else if ( !AsciiStrCmp (Name, "erase-block-size")) {
+    AsciiSPrint (Value, 12, "0x%llx", UFS_BLOCK_SIZE);
+  } else if ( !AsciiStrCmp (Name, "logical-block-size")) {
+    AsciiSPrint (Value, 12, "0x%llx", UFS_BLOCK_SIZE);
   } else {
     *Value = '\0';
   }


### PR DESCRIPTION
Add fastboot parameters "erase-block-size" and "logical-block-size"
for both HiKey and HiKey960 platform.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>