### PR TITLE
Platforms/HiKey: fix truncated kernel args for eMMC boot

### DIFF
--- a/Platforms/Hisilicon/HiKey/HiKey.dsc
+++ b/Platforms/Hisilicon/HiKey/HiKey.dsc
@@ -350,6 +350,11 @@
   #
   gHiKeyTokenSpaceGuid.PcdBootImagePath|L"VenHw(B549F005-4BD4-4020-A0CB-06F42BDA68C3)/HD(6,GPT,5C0F213C-17E1-4149-88C8-8B50FB4EC70E)"
 
+  #
+  # Variable Size
+  #
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize|2048
+
 [PcdsDynamicDefault.common]
   #
   # The size of a dynamic PCD of the (VOID*) type can not be increased at run

--- a/Platforms/Hisilicon/HiKey/HiKeyDxe/InstallBootMenu.c
+++ b/Platforms/Hisilicon/HiKey/HiKeyDxe/InstallBootMenu.c
@@ -244,8 +244,8 @@ HiKeyCreateBootEntry (
 
   if (BootArgs) {
     /* Always force the BootArgs to save 512 characters. */
-    ASSERT (StrSize(BootArgs) <= 512);
-    BdsLoadOption->OptionalDataSize = 512;
+    ASSERT (StrSize(BootArgs) <= 512 * sizeof (CHAR16));
+    BdsLoadOption->OptionalDataSize = 512 * sizeof (CHAR16);
     BdsLoadOption->OptionalData = (CHAR16*)AllocateZeroPool (BdsLoadOption->OptionalDataSize);
     ASSERT (BdsLoadOption->OptionalData != NULL);
     StrCpy (BdsLoadOption->OptionalData, BootArgs);


### PR DESCRIPTION
When boot from eMMC, kernel command args are truncated into 256
characters. It's limited by LoadOptionSize when create Boot variables.

At the same time, need to increase the limitation on variable size.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>