### PR TITLE
Drivers/DwUsbDxe: fix hang on downloading system image

### DIFF
--- a/Drivers/Usb/DwUsbDxe/DwUsbDxe.c
+++ b/Drivers/Usb/DwUsbDxe/DwUsbDxe.c
@@ -516,8 +516,8 @@ CheckInterrupts (
 			  UINTN bytes = rx_desc_bytes - g_dma_desc->status.b.bytes;
 			  UINTN len = 0;
 
-			  if (MATCH_CMD_LITERAL ("download", rx_buf)) {
-				  mNumDataBytes = AsciiStrHexToUint64 (rx_buf + sizeof ("download"));
+			  if (MATCH_CMD_LITERAL ("download:", rx_buf)) {
+				  mNumDataBytes = AsciiStrHexToUint64 (rx_buf + sizeof ("download:"));
 			  } else {
 				if (mNumDataBytes != 0)
 					mNumDataBytes -= bytes;


### PR DESCRIPTION
It parsed "download" string in original code. It may suffer pain
while system image contains "download" string. Use "download:"
string instead.

Signed-off-by: John Stultz <john.stultz@linaro.org>
Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>