### PR TITLE
Drivers/DwUsbDxe: fix usb hang when download system image

### DIFF
--- a/Drivers/Usb/DwUsbDxe/DwUsbDxe.c
+++ b/Drivers/Usb/DwUsbDxe/DwUsbDxe.c
@@ -555,8 +555,8 @@ CheckInterrupts (
         UINTN Len = 0;
 
         ArmDataSynchronizationBarrier ();
-        if (MATCH_CMD_LITERAL ("download", RxBuf)) {
-          mNumDataBytes = AsciiStrHexToUint64 (RxBuf + sizeof ("download"));
+        if (MATCH_CMD_LITERAL ("download:", RxBuf)) {
+          mNumDataBytes = AsciiStrHexToUint64 (RxBuf + sizeof ("download:"));
         } else {
           if (mNumDataBytes != 0) {
             mNumDataBytes -= Bytes;


### PR DESCRIPTION
It seems that "download" string is contained in system image.
Use "download:" string as checking pattern instead.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>