### PR TITLE
hikey: Set HIKEY_ERASE_SIZE to 4096

### DIFF
--- a/Platforms/Hisilicon/HiKey/HiKeyFastbootDxe/HiKeyFastboot.c
+++ b/Platforms/Hisilicon/HiKey/HiKeyFastbootDxe/HiKeyFastboot.c
@@ -50,7 +50,7 @@
 #define SERIAL_NUMBER_LENGTH      16
 #define BOOT_DEVICE_LENGTH        16
 
-#define HIKEY_ERASE_SIZE          512
+#define HIKEY_ERASE_SIZE          4096
 
 typedef struct _FASTBOOT_PARTITION_LIST {
   LIST_ENTRY  Link;


### PR DESCRIPTION
Invalid erase-block-size 512: must be a  power of 2 and at least 4096.
Invalid logical-block-size 512: must be a power of 2 and at least 4096.

Change-Id: I80dd048dde8daf34e8565ca0eeef22239a9e13a0
Signed-off-by: Dmitry Shmidt <dimitrysh@google.com>