### PR TITLE
Platforms/HiKey: disable SD card temporary

### DIFF
--- a/Platforms/Hisilicon/HiKey/HiKey.dsc
+++ b/Platforms/Hisilicon/HiKey/HiKey.dsc
@@ -425,7 +425,7 @@
   MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceDxe.inf
   OpenPlatformPkg/Drivers/SdMmc/DwMmcHcDxe/DwMmcHcDxe.inf
   MdeModulePkg/Bus/Sd/EmmcDxe/EmmcDxe.inf
-  MdeModulePkg/Bus/Sd/SdDxe/SdDxe.inf
+  #MdeModulePkg/Bus/Sd/SdDxe/SdDxe.inf
 
   OpenPlatformPkg/Platforms/Hisilicon/HiKey/HiKeyDxe/HiKeyDxe.inf
 

--- a/Platforms/Hisilicon/HiKey/HiKey.fdf
+++ b/Platforms/Hisilicon/HiKey/HiKey.fdf
@@ -132,7 +132,7 @@ READ_LOCK_STATUS   = TRUE
   INF MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceDxe.inf
   INF OpenPlatformPkg/Drivers/SdMmc/DwMmcHcDxe/DwMmcHcDxe.inf
   INF MdeModulePkg/Bus/Sd/EmmcDxe/EmmcDxe.inf
-  INF MdeModulePkg/Bus/Sd/SdDxe/SdDxe.inf
+  #INF MdeModulePkg/Bus/Sd/SdDxe/SdDxe.inf
 
   INF OpenPlatformPkg/Platforms/Hisilicon/HiKey/HiKeyDxe/HiKeyDxe.inf
 


### PR DESCRIPTION
When SD card is enabled, SD and eMMC are recognized as HD0 and HD1.
It breaks the assumption that eMMC is the first HD.

So disable SD card as a workaround.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>