### PR TITLE
Drivers/DwUsb3Dxe: increate data buffer from 512B to 128KB

### DIFF
--- a/Drivers/Usb/DwUsb3Dxe/DwUsb3Dxe.c
+++ b/Drivers/Usb/DwUsb3Dxe/DwUsb3Dxe.c
@@ -43,7 +43,7 @@
 
 #define USB_TYPE_LENGTH              16
 #define USB_BLOCK_HIGH_SPEED_SIZE    512
-#define DATA_SIZE                    512
+#define DATA_SIZE                    131072
 #define CMD_SIZE                     512
 #define MATCH_CMD_LITERAL(Cmd, Buf) !AsciiStrnCmp (Cmd, Buf, sizeof (Cmd) - 1)
 


### PR DESCRIPTION
Increase the data buffer from 512B to 128KB. It could improve
the performance of usb transmission.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>