### PR TITLE
Platforms/HiKeyFastbootDxe: fix block size to 4KB

### DIFF
--- a/Platforms/Hisilicon/HiKey/HiKeyFastbootDxe/HiKeyFastbootDxe.c
+++ b/Platforms/Hisilicon/HiKey/HiKeyFastbootDxe/HiKeyFastbootDxe.c
@@ -47,6 +47,7 @@
 #define ADB_REBOOT_BOOTLOADER            0x77665500
 
 #define MMC_BLOCK_SIZE                   512
+#define HIKEY_ERASE_SIZE                 4096
 
 typedef struct _FASTBOOT_PARTITION_LIST {
   LIST_ENTRY  Link;
@@ -517,9 +518,9 @@ HiKeyFastbootPlatformGetVar (
       AsciiStrCpy (Value, "raw");
     }
   } else if ( !AsciiStrCmp (Name, "erase-block-size")) {
-    AsciiSPrint (Value, 12, "0x%llx", MMC_BLOCK_SIZE);
+    AsciiSPrint (Value, 12, "0x%llx", HIKEY_ERASE_SIZE);
   } else if ( !AsciiStrCmp (Name, "logical-block-size")) {
-    AsciiSPrint (Value, 12, "0x%llx", MMC_BLOCK_SIZE);
+    AsciiSPrint (Value, 12, "0x%llx", HIKEY_ERASE_SIZE);
   } else {
     *Value = '\0';
   }


### PR DESCRIPTION
It's used to create FS on host side. ext4 fs is always 4KB alignment.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>