### PR TITLE
Drivers/DwMmcHcDxe: fix the accessing length

### DIFF
--- a/Drivers/SdMmc/DwMmcHcDxe/DwMmcHci.c
+++ b/Drivers/SdMmc/DwMmcHcDxe/DwMmcHci.c
@@ -135,14 +135,16 @@ DwMmcHcRwMmio (
     return EFI_INVALID_PARAMETER;
   }
 
-  if ((Count != 1) && (Count != 2) && (Count != 4) && (Count != 8)) {
+  if ((Count != 4) && (Count != 8)) {
     return EFI_INVALID_PARAMETER;
   }
 
+  // Since there's FIFO in Designware controller, map it to 32-bit word only.
+  Count = Count / sizeof (UINT32);
   if (Read) {
     Status = PciIo->Mem.Read (
                           PciIo,
-                          EfiPciIoWidthUint8,
+                          EfiPciIoWidthUint32,
                           BarIndex,
                           (UINT64) Offset,
                           Count,
@@ -151,7 +153,7 @@ DwMmcHcRwMmio (
   } else {
     Status = PciIo->Mem.Write (
                           PciIo,
-                          EfiPciIoWidthUint8,
+                          EfiPciIoWidthUint32,
                           BarIndex,
                           (UINT64) Offset,
                           Count,


### PR DESCRIPTION
Since FIFO is used in designware eMMC/SD controller, it should be
accessed with data length at one time. Original implementation
will split the read operation of FIFO into four bytes reading.
It causes FIFO underflow.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>