### PR TITLE
Platforms/HiKey960: support gzip compressed kernel image

### DIFF
--- a/Platforms/Hisilicon/HiKey/HiKey.dsc
+++ b/Platforms/Hisilicon/HiKey/HiKey.dsc
@@ -131,7 +131,7 @@
 [LibraryClasses.common.SEC]
   PrePiLib|EmbeddedPkg/Library/PrePiLib/PrePiLib.inf
   ExtractGuidedSectionLib|EmbeddedPkg/Library/PrePiExtractGuidedSectionLib/PrePiExtractGuidedSectionLib.inf
-  LzmaDecompressLib|IntelFrameworkModulePkg/Library/LzmaCustomDecompressLib/LzmaCustomDecompressLib.inf
+  LzmaDecompressLib|MdeModulePkg/Library/LzmaCustomDecompressLib/LzmaCustomDecompressLib.inf
   MemoryAllocationLib|EmbeddedPkg/Library/PrePiMemoryAllocationLib/PrePiMemoryAllocationLib.inf
   HobLib|EmbeddedPkg/Library/PrePiHobLib/PrePiHobLib.inf
   PrePiHobListPointerLib|ArmPlatformPkg/Library/PrePiHobListPointerLib/PrePiHobListPointerLib.inf
@@ -455,7 +455,9 @@
   #
   EmbeddedPkg/Application/AndroidFastboot/AndroidFastbootApp.inf {
     <LibraryClasses>
+      AbootimgLib|EmbeddedPkg/Library/AbootimgLib/AbootimgLib.inf
       BdsLib|ArmPkg/Library/BdsLib/BdsLib.inf
+      ZLib|EmbeddedPkg/Library/ZLib/ZLib.inf
   }
 
   #
@@ -463,7 +465,9 @@
   #
   EmbeddedPkg/Application/AndroidBoot/AndroidBootApp.inf {
     <LibraryClasses>
+      AbootimgLib|EmbeddedPkg/Library/AbootimgLib/AbootimgLib.inf
       BdsLib|ArmPkg/Library/BdsLib/BdsLib.inf
+      ZLib|EmbeddedPkg/Library/ZLib/ZLib.inf
   }
 
   #

--- a/Platforms/Hisilicon/HiKey960/HiKey960.dsc
+++ b/Platforms/Hisilicon/HiKey960/HiKey960.dsc
@@ -62,7 +62,6 @@
   CapsuleLib|MdeModulePkg/Library/DxeCapsuleLibNull/DxeCapsuleLibNull.inf
   GenericBdsLib|IntelFrameworkModulePkg/Library/GenericBdsLib/GenericBdsLib.inf
   PlatformBdsLib|OpenPlatformPkg/Chips/Hisilicon/Library/PlatformIntelBdsLib/PlatformIntelBdsLib.inf
-  AbootimgLib|EmbeddedPkg/Library/AbootimgLib/AbootimgLib.inf
   FdtLib|EmbeddedPkg/Library/FdtLib/FdtLib.inf
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
@@ -133,7 +132,6 @@
   PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
   PrePiLib|EmbeddedPkg/Library/PrePiLib/PrePiLib.inf
   ExtractGuidedSectionLib|EmbeddedPkg/Library/PrePiExtractGuidedSectionLib/PrePiExtractGuidedSectionLib.inf
-  LzmaDecompressLib|IntelFrameworkModulePkg/Library/LzmaCustomDecompressLib/LzmaCustomDecompressLib.inf
   MemoryAllocationLib|EmbeddedPkg/Library/PrePiMemoryAllocationLib/PrePiMemoryAllocationLib.inf
   HobLib|EmbeddedPkg/Library/PrePiHobLib/PrePiHobLib.inf
   PrePiHobListPointerLib|ArmPlatformPkg/Library/PrePiHobListPointerLib/PrePiHobListPointerLib.inf
@@ -142,6 +140,7 @@
   MemoryInitPeiLib|ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.inf
   ArmGicArchLib|ArmPkg/Library/ArmGicArchSecLib/ArmGicArchSecLib.inf
   DefaultExceptionHandlerLib|ArmPkg/Library/DefaultExceptionHandlerLib/DefaultExceptionHandlerLibBase.inf
+  LzmaDecompressLib|MdeModulePkg/Library/LzmaCustomDecompressLib/LzmaCustomDecompressLib.inf
 
 [LibraryClasses.common.DXE_CORE]
   DxeCoreEntryPoint|MdePkg/Library/DxeCoreEntryPoint/DxeCoreEntryPoint.inf
@@ -501,7 +500,9 @@
   #
   EmbeddedPkg/Application/AndroidFastboot/AndroidFastbootApp.inf {
     <LibraryClasses>
+      AbootimgLib|EmbeddedPkg/Library/AbootimgLib/AbootimgLib.inf
       BdsLib|ArmPkg/Library/BdsLib/BdsLib.inf
+      ZLib|EmbeddedPkg/Library/ZLib/ZLib.inf
   }
 
   #
@@ -509,7 +510,9 @@
   #
   EmbeddedPkg/Application/AndroidBoot/AndroidBootApp.inf {
     <LibraryClasses>
+      AbootimgLib|EmbeddedPkg/Library/AbootimgLib/AbootimgLib.inf
       BdsLib|ArmPkg/Library/BdsLib/BdsLib.inf
+      ZLib|EmbeddedPkg/Library/ZLib/ZLib.inf
   }
 
   #


### PR DESCRIPTION
Support gzip compressed kernel on both HiKey and HiKey960 platform.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>