### PR TITLE
Platform/HiKey960: remove earlycon parameter

### DIFF
--- a/Platforms/Hisilicon/HiKey960/HiKey960Dxe/HiKey960Dxe.c
+++ b/Platforms/Hisilicon/HiKey960/HiKey960Dxe/HiKey960Dxe.c
@@ -412,13 +412,13 @@ AbootimgAppendKernelArgs (
   if (mBoardId == HIKEY960_BOARDID_V1) {
     UnicodeSPrint (
       Args + StrLen (Args), Size - StrLen (Args),
-      L" earlycon=pl011,0xfdf05000,115200 console=ttyAMA5 androidboot.serialno=%s",
+      L" console=ttyAMA5 androidboot.serialno=%s",
       RandomSN->UnicodeSN
       );
   } else {
     UnicodeSPrint (
       Args + StrLen (Args), Size - StrLen (Args),
-      L" earlycon=pl011,0xfff32000,115200 console=ttyAMA6 androidboot.serialno=%s",
+      L" console=ttyAMA6 androidboot.serialno=%s",
       RandomSN->UnicodeSN
       );
   }


### PR DESCRIPTION
Don't need to append "earlycon" kernel parameter in bootloader.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>