### PR TITLE
Revert "Platforms/HiKey: disable SD card temporary"

### DIFF
--- a/Platforms/Hisilicon/HiKey/HiKey.dsc
+++ b/Platforms/Hisilicon/HiKey/HiKey.dsc
@@ -428,7 +428,7 @@
   MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceDxe.inf
   OpenPlatformPkg/Drivers/SdMmc/DwMmcHcDxe/DwMmcHcDxe.inf
   MdeModulePkg/Bus/Sd/EmmcDxe/EmmcDxe.inf
-  #MdeModulePkg/Bus/Sd/SdDxe/SdDxe.inf
+  MdeModulePkg/Bus/Sd/SdDxe/SdDxe.inf
 
   OpenPlatformPkg/Platforms/Hisilicon/HiKey/HiKeyDxe/HiKeyDxe.inf
 

--- a/Platforms/Hisilicon/HiKey/HiKey.fdf
+++ b/Platforms/Hisilicon/HiKey/HiKey.fdf
@@ -132,7 +132,7 @@ READ_LOCK_STATUS   = TRUE
   INF MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceDxe.inf
   INF OpenPlatformPkg/Drivers/SdMmc/DwMmcHcDxe/DwMmcHcDxe.inf
   INF MdeModulePkg/Bus/Sd/EmmcDxe/EmmcDxe.inf
-  #INF MdeModulePkg/Bus/Sd/SdDxe/SdDxe.inf
+  INF MdeModulePkg/Bus/Sd/SdDxe/SdDxe.inf
 
   INF OpenPlatformPkg/Platforms/Hisilicon/HiKey/HiKeyDxe/HiKeyDxe.inf
 


### PR DESCRIPTION
This reverts commit 04680f1f01a0863b3578250f8e5833c39c5b6f75.

SD card can now be enabled again with grub using labels to find
grub.cfg