### PR TITLE
Platforms/Hisilicon: fix arrow keys in release build

### DIFF
--- a/Platforms/Hisilicon/HiKey/HiKey.dsc
+++ b/Platforms/Hisilicon/HiKey/HiKey.dsc
@@ -315,6 +315,7 @@
   DEFINE SERIAL_BASE = 0xF7113000 # UART3
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase|$(SERIAL_BASE)
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultBaudRate|115200
+  gEfiMdePkgTokenSpaceGuid.PcdUartDefaultReceiveFifoDepth|0
   gArmPlatformTokenSpaceGuid.PL011UartInteger|10
   gArmPlatformTokenSpaceGuid.PL011UartFractional|26
 

--- a/Platforms/Hisilicon/HiKey960/HiKey960.dsc
+++ b/Platforms/Hisilicon/HiKey960/HiKey960.dsc
@@ -311,6 +311,7 @@
   DEFINE SERIAL_BASE = 0xFFF32000
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase|$(SERIAL_BASE)
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultBaudRate|115200
+  gEfiMdePkgTokenSpaceGuid.PcdUartDefaultReceiveFifoDepth|0
   gArmPlatformTokenSpaceGuid.PL011UartInteger|10
   gArmPlatformTokenSpaceGuid.PL011UartFractional|26
 


### PR DESCRIPTION
The key is in the receive FIFO in PL011 driver. This driver supports
of 1, 16 or 32 chars.

Arrow key is presented as 3 chars. For example, DOWN key is "~[B".
By default, PcdUartDefaultReceiveFifoDepth is fixed at 1. It means
that arrow key is truncated. So it can't be worked well.

After updating to 0, the FIFO depth will be set either 16 or 32 chars.
The logic is in below.

  HardwareFifoDepth = (PL011_UARTPID2_VER (MmioRead32 (UartBase + UARTPID2)) \
                       > PL011_VER_R1P4) \
                      ? 32 : 16 ;

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>