### PR TITLE
HiKey960/Mmc: update the interface of card detection

### DIFF
--- a/Platforms/Hisilicon/HiKey960/HiKey960MmcDxe/HiKey960MmcDxe.c
+++ b/Platforms/Hisilicon/HiKey960/HiKey960MmcDxe/HiKey960MmcDxe.c
@@ -67,6 +67,7 @@ HiKey960GetCapability (
 BOOLEAN
 EFIAPI
 HiKey960CardDetect (
+  IN EFI_HANDLE               Controller,
   IN UINT8                    Slot
   )
 {


### PR DESCRIPTION
Update the interface of card detection. The parameter of
"controller" is added.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>