### PR TITLE
Platform/HiKey960: add warning message

### DIFF
--- a/Platforms/Hisilicon/HiKey960/HiKey960Dxe/HiKey960Dxe.c
+++ b/Platforms/Hisilicon/HiKey960/HiKey960Dxe/HiKey960Dxe.c
@@ -29,6 +29,7 @@
 #include <Library/IoLib.h>
 #include <Library/PcdLib.h>
 #include <Library/PrintLib.h>
+#include <Library/SerialPortLib.h>
 #include <Library/TimerLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
@@ -95,6 +96,12 @@ typedef struct {
   UINT64        Data;
   CHAR16        UnicodeSN[SERIAL_NUMBER_SIZE];
 } RANDOM_SERIAL_NUMBER;
+
+enum {
+  BOOT_MODE_RECOVERY  = 0,
+  BOOT_MODE_NORMAL,
+  BOOT_MODE_MASK = 1,
+};
 
 STATIC UINTN    mBoardId;
 
@@ -348,6 +355,13 @@ OnEndOfDxe (
   IN VOID       *Context
   )
 {
+  UINT32        BootMode;
+
+  BootMode = MmioRead32 (SCTRL_BAK_DATA0) & BOOT_MODE_MASK;
+  if (BootMode == BOOT_MODE_RECOVERY) {
+    SerialPortWrite ((UINT8 *)"WARNING: CAN NOT BOOT KERNEL IN RECOVERY MODE!\r\n", 48);
+    SerialPortWrite ((UINT8 *)"Switch to normal boot mode, then reboot to boot kernel.\r\n", 57);
+  }
 }
 
 EFI_STATUS

--- a/Platforms/Hisilicon/HiKey960/HiKey960Dxe/HiKey960Dxe.inf
+++ b/Platforms/Hisilicon/HiKey960/HiKey960Dxe/HiKey960Dxe.inf
@@ -39,6 +39,7 @@
   NonDiscoverableDeviceRegistrationLib
   PcdLib
   PrintLib
+  SerialPortLib
   TimerLib
   UefiBootServicesTableLib
   UefiDriverEntryPoint

--- a/Platforms/Hisilicon/HiKey960/Include/Hi3660.h
+++ b/Platforms/Hisilicon/HiKey960/Include/Hi3660.h
@@ -30,6 +30,8 @@
 #define SCTRL_SCFPLLCTRL0                       (SCTRL_REG_BASE + 0x120)
 #define SCTRL_SCFPLLCTRL0_FPLL0_EN              (1 << 0)
 
+#define SCTRL_BAK_DATA0                         (SCTRL_REG_BASE + 0x40C)
+
 #define USB3OTG_BC_REG_BASE                     0xFF200000
 
 #define USB3OTG_CTRL0                           (USB3OTG_BC_REG_BASE + 0x000)


### PR DESCRIPTION
Add warning message for recovery mode. User shouldn't boot
kernel in recovery mode. Since BL31 won't be loaded and
some devices are not initialized in recovery mode.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>