### PR TITLE
Platforms/HiKey960: fix product string

### DIFF
--- a/Platforms/Hisilicon/HiKey960/HiKey960.dsc
+++ b/Platforms/Hisilicon/HiKey960/HiKey960.dsc
@@ -282,7 +282,7 @@
   gEmbeddedTokenSpaceGuid.PcdEmbeddedDefaultTextColor|0x07
   gEmbeddedTokenSpaceGuid.PcdEmbeddedMemVariableStoreSize|0x10000
 
-  gArmPlatformTokenSpaceGuid.PcdFirmwareVendor|"Linaro"
+  gArmPlatformTokenSpaceGuid.PcdFirmwareVendor|"HiKey960"
   gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString|L"Alpha"
   gEmbeddedTokenSpaceGuid.PcdEmbeddedPrompt|"HiKey960"
 


### PR DESCRIPTION
Fix product string from "Linaro" to "HiKey960".

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>