### PR TITLE
Platforms/HiKey960Dxe: check flag before clearing virtual key

### DIFF
--- a/Platforms/Hisilicon/HiKey960/HiKey960Dxe/HiKey960Dxe.c
+++ b/Platforms/Hisilicon/HiKey960/HiKey960Dxe/HiKey960Dxe.c
@@ -104,6 +104,7 @@ enum {
 };
 
 STATIC UINTN    mBoardId;
+STATIC UINTN    mReboot;
 
 STATIC EMBEDDED_GPIO   *mGpio;
 
@@ -617,7 +618,8 @@ VirtualKeyboardClear (
   if (VirtualKey == NULL) {
     return EFI_INVALID_PARAMETER;
   }
-  if (MmioRead32 (ADB_REBOOT_ADDRESS) == ADB_REBOOT_BOOTLOADER) {
+  // Only clear the reboot flag that is set before reboot.
+  if (mReboot && (MmioRead32 (ADB_REBOOT_ADDRESS) == ADB_REBOOT_BOOTLOADER)) {
     MmioWrite32 (ADB_REBOOT_ADDRESS, ADB_REBOOT_NONE);
     WriteBackInvalidateDataCacheRange ((VOID *)ADB_REBOOT_ADDRESS, 4);
   }
@@ -647,6 +649,11 @@ HiKey960EntryPoint (
   }
 
   InitPeripherals ();
+
+  // Record whether the reboot flag was set before reboot
+  if (MmioRead32 (ADB_REBOOT_ADDRESS) == ADB_REBOOT_BOOTLOADER) {
+    mReboot = 1;
+  }
 
   //
   // Create an event belonging to the "gEfiEndOfDxeEventGroupGuid" group.


### PR DESCRIPTION
Add reboot flag before checking virtual key of reboot reason. Since
we add the delay before reboot, the virtual key event will be
clear automatically by virtual key driver. Add the reboot flag
to guranatee the clear option could only be executed for reboot
scenario.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>