### PR TITLE
Platforms/HiKey960: Support 4G or more memory space for RAM

### DIFF
--- a/Platforms/Hisilicon/HiKey960/Include/Hi3660.h
+++ b/Platforms/Hisilicon/HiKey960/Include/Hi3660.h
@@ -144,4 +144,7 @@
 #define MASK_UFS_DEVICE_RESET                   (1 << 16)
 #define BIT_UFS_DEVICE_RESET                    (1 << 0)
 
+#define SCTRL_SCBAKDATA7                        (SCTRL_REG_BASE + 0x428)
+#define HIKEY_REGION_SIZE(x)                    ((((x) >> 0x8) & 0xF) << 30)
+
 #endif /* __HI3660_H__ */


### PR DESCRIPTION
Currently, Hikey960 has two different manufactured forms, one is with
3GB DDR RAM and another has 4GB DDR RAM, so this patch adds
support to dynamically adapt DDR RAM size as needed at booting
time.

[leoy: rephrase the commit log]

Cc: Haojian Zhuang <haojian.zhuang@linaro.org>
Cc: fengbaopeng@hisilicon.com
Signed-off-by: Li Wei <liwei213@huawei.com>