### PR TITLE
Drivers/DwUsbDxe: fix hang in fastboot boot command

### DIFF
--- a/Drivers/Usb/DwUsbDxe/DwUsbDxe.c
+++ b/Drivers/Usb/DwUsbDxe/DwUsbDxe.c
@@ -197,7 +197,7 @@ EpRx (
     RxDescBytes = Len;
   }
 
-  RxBuf = AllocatePool (DATA_SIZE);
+  RxBuf = AllocateZeroPool (DATA_SIZE);
   ASSERT (RxBuf != NULL);
 
   InvalidateDataCacheRange (RxBuf, Len);


### PR DESCRIPTION
When execute "fastboot boot boot.img" for several times on HiKey
platform, it may hang in downloading process. This issue only
exists in release build.

After allocating memory with zero value assigned, this issue is
gone.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>